### PR TITLE
Change VOCopts.detrespath based on VOCopts.testset

### DIFF
--- a/lib/datasets/VOCdevkit-matlab-wrapper/voc_eval.m
+++ b/lib/datasets/VOCdevkit-matlab-wrapper/voc_eval.m
@@ -2,6 +2,7 @@ function res = voc_eval(path, comp_id, test_set, output_dir, rm_res)
 
 VOCopts = get_voc_opts(path);
 VOCopts.testset = test_set;
+VOCopts.detrespath=[VOCopts.resdir 'Main/%s_det_' VOCopts.testset '_%s.txt'];
 
 for i = 1:length(VOCopts.classes)
   cls = VOCopts.classes{i};


### PR DESCRIPTION
Hi Ross,

While I was going through the instruction for testing a fast-rcnn, I got a "file not found" error in VOCevaldet (line 30). This can be fixed by resetting VOCopts.detrespath to point to the correct text files based on VOCopts.testset. 

- Kota