### PR TITLE
Assert at least one label for training

### DIFF
--- a/lib/roi_data_layer/minibatch.py
+++ b/lib/roi_data_layer/minibatch.py
@@ -54,6 +54,9 @@ def get_minibatch(roidb, num_classes):
     # For debug visualizations
     # _vis_minibatch(im_blob, rois_blob, labels_blob, all_overlaps)
 
+    assert len(labels_blob) > 0, "There are no labels: this can results if"\
+        "images have no fg objects and TRAIN.BG_THRESH_LO > 0"
+
     blobs = {'data': im_blob,
              'rois': rois_blob,
              'labels': labels_blob}


### PR DESCRIPTION
Added an assert statement to ensure that there is at least one label and roi
for the minibatch. If this is not the case, the training starts however results
in a floating point error which doesn't give the clear cause. This situation
can result from having images which are entirely negatives but not having
TRAIN.BG_THRESH_LO set to zero.