### PR TITLE
Allow training to succeed with negative images

### DIFF
--- a/lib/datasets/imdb.py
+++ b/lib/datasets/imdb.py
@@ -161,13 +161,16 @@ class imdb(object):
 
             if gt_roidb is not None:
                 gt_boxes = gt_roidb[i]['boxes']
-                gt_classes = gt_roidb[i]['gt_classes']
-                gt_overlaps = bbox_overlaps(boxes.astype(np.float),
+
+                #Need at least one box for argmax
+                if gt_boxes.shape[0] > 0: 
+                    gt_classes = gt_roidb[i]['gt_classes']
+                    gt_overlaps = bbox_overlaps(boxes.astype(np.float),
                                             gt_boxes.astype(np.float))
-                argmaxes = gt_overlaps.argmax(axis=1)
-                maxes = gt_overlaps.max(axis=1)
-                I = np.where(maxes > 0)[0]
-                overlaps[I, gt_classes[argmaxes[I]]] = maxes[I]
+                    argmaxes = gt_overlaps.argmax(axis=1)
+                    maxes = gt_overlaps.max(axis=1)
+                    I = np.where(maxes > 0)[0]
+                    overlaps[I, gt_classes[argmaxes[I]]] = maxes[I]
 
             overlaps = scipy.sparse.csr_matrix(overlaps)
             roidb.append({'boxes' : boxes,
@@ -184,10 +187,17 @@ class imdb(object):
             a[i]['boxes'] = np.vstack((a[i]['boxes'], b[i]['boxes']))
             a[i]['gt_classes'] = np.hstack((a[i]['gt_classes'],
                                             b[i]['gt_classes']))
-            a[i]['gt_overlaps'] = scipy.sparse.vstack([a[i]['gt_overlaps'],
-                                                       b[i]['gt_overlaps']])
+            a[i]['gt_overlaps'] = imdb.vstack([a[i]['gt_overlaps'],
+                                               b[i]['gt_overlaps']])
+            
         return a
 
+    @staticmethod
+    def vstack(blocks):
+        """As spipy.sparse.vstack, but allowing for the lack of gt overlaps"""
+        blocks = [[block] for block in blocks if block.shape[0]]
+        return scipy.sparse.bmat(blocks)
+        
     def competition_mode(self, on):
         """Turn competition mode on or off."""
         pass

--- a/lib/roi_data_layer/layer.py
+++ b/lib/roi_data_layer/layer.py
@@ -12,7 +12,7 @@ RoIDataLayer implements a Caffe Python layer.
 
 import caffe
 from fast_rcnn.config import cfg
-from roi_data_layer.minibatch import get_minibatch
+from roi_data_layer.minibatch import get_minibatch, NoLabels
 import numpy as np
 import yaml
 from multiprocessing import Process, Queue
@@ -43,9 +43,13 @@ class RoIDataLayer(caffe.Layer):
         if cfg.TRAIN.USE_PREFETCH:
             return self._blob_queue.get()
         else:
-            db_inds = self._get_next_minibatch_inds()
-            minibatch_db = [self._roidb[i] for i in db_inds]
-            return get_minibatch(minibatch_db, self._num_classes)
+            while True:
+                db_inds = self._get_next_minibatch_inds()
+                minibatch_db = [self._roidb[i] for i in db_inds]
+                try:
+                    return get_minibatch(minibatch_db, self._num_classes)
+                except NoLabels:
+                    pass #Have another go                    
 
     def set_roidb(self, roidb):
         """Set the roidb to be used by this layer during training."""
@@ -156,5 +160,8 @@ class BlobFetcher(Process):
         while True:
             db_inds = self._get_next_minibatch_inds()
             minibatch_db = [self._roidb[i] for i in db_inds]
-            blobs = get_minibatch(minibatch_db, self._num_classes)
-            self._queue.put(blobs)
+            try:
+                blobs = get_minibatch(minibatch_db, self._num_classes)
+                self._queue.put(blobs)
+            except NoLabels:
+                pass #Keep looping

--- a/lib/roi_data_layer/minibatch.py
+++ b/lib/roi_data_layer/minibatch.py
@@ -54,6 +54,9 @@ def get_minibatch(roidb, num_classes):
     # For debug visualizations
     # _vis_minibatch(im_blob, rois_blob, labels_blob, all_overlaps)
 
+    assert len(labels_blob) > 0, "There are no labels: this can results if"\
+        "images have no fg objects and TRAIN.BG_THRESH_LO > 0"
+
     blobs = {'data': im_blob,
              'rois': rois_blob,
              'labels': labels_blob}

--- a/lib/roi_data_layer/minibatch.py
+++ b/lib/roi_data_layer/minibatch.py
@@ -13,6 +13,9 @@ import cv2
 from fast_rcnn.config import cfg
 from utils.blob import prep_im_for_blob, im_list_to_blob
 
+class NoLabels(Exception):
+    pass
+
 def get_minibatch(roidb, num_classes):
     """Given a roidb, construct a minibatch sampled from it."""
     num_images = len(roidb)
@@ -54,8 +57,8 @@ def get_minibatch(roidb, num_classes):
     # For debug visualizations
     # _vis_minibatch(im_blob, rois_blob, labels_blob, all_overlaps)
 
-    assert len(labels_blob) > 0, "There are no labels: this can results if"\
-        "images have no fg objects and TRAIN.BG_THRESH_LO > 0"
+    if len(labels_blob) == 0:
+        raise NoLabels
 
     blobs = {'data': im_blob,
              'rois': rois_blob,

--- a/lib/roi_data_layer/roidb.py
+++ b/lib/roi_data_layer/roidb.py
@@ -95,6 +95,12 @@ def _compute_targets(rois, overlaps, labels):
     ex_gt_overlaps = utils.cython_bbox.bbox_overlaps(rois[ex_inds, :],
                                                      rois[gt_inds, :])
 
+    targets = np.zeros((rois.shape[0], 5), dtype=np.float32)
+
+    #No gt or no overlaps above threshold
+    if len(ex_gt_overlaps) == 0:
+        return targets
+
     # Find which gt ROI each ex ROI has max overlap with:
     # this will be the ex ROI's gt target
     gt_assignment = ex_gt_overlaps.argmax(axis=1)
@@ -116,7 +122,6 @@ def _compute_targets(rois, overlaps, labels):
     targets_dw = np.log(gt_widths / ex_widths)
     targets_dh = np.log(gt_heights / ex_heights)
 
-    targets = np.zeros((rois.shape[0], 5), dtype=np.float32)
     targets[ex_inds, 0] = labels[ex_inds]
     targets[ex_inds, 1] = targets_dx
     targets[ex_inds, 2] = targets_dy


### PR DESCRIPTION
Allows training to succeed when there are images present without any ground
truth boxes. Previously, this failed due to merging empty matrices, argmax over
empty matrices or the lack of an objective.

This supercedes 75b3fd (Assert at least one label for training) which would
pick up the lack of an objective.