### PR TITLE
fix a tiny defect of getting xml tag

### DIFF
--- a/lib/datasets/pascal_voc.py
+++ b/lib/datasets/pascal_voc.py
@@ -195,6 +195,13 @@ class pascal_voc(datasets.imdb):
         """
         filename = os.path.join(self._data_path, 'Annotations', index + '.xml')
         # print 'Loading: {}'.format(filename)
+
+        # http://stackoverflow.com/questions/1596829/xml-parsing-with-python-and-minidom
+        def getChildrenByTagName(node, tagName):
+            for child in node.childNodes:
+                if child.nodeType == child.ELEMENT_NODE and (tagName == '*' or child.tagName == tagName):
+                    return child
+
         def get_data_from_tag(node, tag):
             return node.getElementsByTagName(tag)[0].childNodes[0].data
 
@@ -210,11 +217,12 @@ class pascal_voc(datasets.imdb):
 
         # Load object bounding boxes into a data frame.
         for ix, obj in enumerate(objs):
+            bndbox_in_obj = getChildrenByTagName(obj, 'bndbox')
             # Make pixel indexes 0-based
-            x1 = float(get_data_from_tag(obj, 'xmin')) - 1
-            y1 = float(get_data_from_tag(obj, 'ymin')) - 1
-            x2 = float(get_data_from_tag(obj, 'xmax')) - 1
-            y2 = float(get_data_from_tag(obj, 'ymax')) - 1
+            x1 = float(get_data_from_tag(bndbox_in_obj, 'xmin')) - 1
+            y1 = float(get_data_from_tag(bndbox_in_obj, 'ymin')) - 1
+            x2 = float(get_data_from_tag(bndbox_in_obj, 'xmax')) - 1
+            y2 = float(get_data_from_tag(bndbox_in_obj, 'ymax')) - 1
             cls = self._class_to_ind[
                     str(get_data_from_tag(obj, "name")).lower().strip()]
             boxes[ix, :] = [x1, y1, x2, y2]


### PR DESCRIPTION
I found there is one tiny defect in _load_pascal_annotation, pascal_voc.py, which may produce some invalid bounding-boxes while training/testing. Some VOC2007 annotations for “person” class, such as VOC2007/Annotations/001627.xml, have many “part” nodes inside “object” node. Take that as an example, what we really need is a bbox [104, 7, 280, 475]-(“person”), but current code will give us a bbox [177, 9, 238, 89]-(“head”), which is not correct.
The point is that: getElementsByTagName is recursive, it’ll get all descendents with a matching tagName “xmin/xmax/ymin/ymax”, so obviously just returning the first element is not appropriate (often the right bbox is the last element).
I add a simple filter to find the very matching direct childrenNode only (tagName “bndbox”), and don't rely on other 3rd party package. As a reference, I use the code from:
http://stackoverflow.com/questions/1596829/xml-parsing-with-python-and-minidom
This PR will correct about 70 "person" object annotations of VOC2007, a tiny portion of dataset :)